### PR TITLE
Update the spdx headers and PROJECT_GOVERNANCE.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2022 Contributors to the Power Grid Model project <dynamic.grid.calculation@alliander.com>
-
-SPDX-License-Identifier: MPL-2.0
+SPDX-FileCopyrightText: 2014 Coraline Ada Ehmke
+SPDX-License-Identifier: CC-BY-4.0
 -->
 
 # Code of Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Contributors to the Power Grid Model project <dynamic.grid.calculation@alliander.com>
+SPDX-FileCopyrightText: 2022 Contributors to the Power Grid Model Workshop project <dynamic.grid.calculation@alliander.com>
 
 SPDX-License-Identifier: MPL-2.0
 -->

--- a/PROJECT_GOVERNANCE.md
+++ b/PROJECT_GOVERNANCE.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Contributors to the Power Grid Model project <dynamic.grid.calculation@alliander.com>
+SPDX-FileCopyrightText: 2022 Contributors to the Power Grid Model workshop project <dynamic.grid.calculation@alliander.com>
 
 SPDX-License-Identifier: MPL-2.0
 -->
@@ -20,7 +20,6 @@ The Technical Steering Committee (TSC) is responsible for:
 1. Raise subjects/issues that are important for the direction/development of this project
 
 The community council consists of the following members:
-1. Aditya Hekker
 1. Tony Xiang
 1. Werner van Westering
 1. Jonas van den Bogaard

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2022 Contributors to the Power Grid Model Workshop project <dynamic.grid.calculation@alliander.com>
+
+SPDX-License-Identifier: MPL-2.0
+-->
+
 # Power Grid Model Workshop
 
 The steps for workshop are to follow `Power Flow Example.ipynb` and `Power Flow Assignment.ipynb` simultaneously.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,12 +1,12 @@
 <!--
-SPDX-FileCopyrightText: 2022 Contributors to the Power Grid Model project <dynamic.grid.calculation@alliander.com>
+SPDX-FileCopyrightText: 2022 Contributors to the Power Grid Model workshop project <dynamic.grid.calculation@alliander.com>
 
 SPDX-License-Identifier: MPL-2.0
 -->
 
 # Getting Help
 
-There are a few ways to connect with the `power-grid-model` project:
+There are a few ways to connect with the `power-grid-model-workshop` project:
 
 * Submit an issue
 * Send an email to the Technical Steering Committee: <dynamic.grid.calculation@alliander.com>.


### PR DESCRIPTION
I made the following update to the PROJECT_GOVERNANCE.md:

Removed Aditya Hekker from the TSC

And updated the SPDX headers to:

SPDX-FileCopyrightText: 2022 Contributors to the Power Grid Model workshop project <dynamic.grid.calculation@alliander.com>
SPDX-License-Identifier: MPL-2.0

